### PR TITLE
Deploys from the Replicated registry

### DIFF
--- a/bundle/.imgpkg/images.yml
+++ b/bundle/.imgpkg/images.yml
@@ -2,12 +2,12 @@
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
-    kbld.carvel.dev/id: springio/petclinic:latest
+    kbld.carvel.dev/id: registry.replicated.com/spring-pet-clinic-stinkbug/petclinic
     kbld.carvel.dev/origins: |
       - resolved:
           tag: latest
-          url: springio/petclinic:latest
+          url: registry.replicated.com/spring-pet-clinic-stinkbug/petclinic
       - preresolved:
-          url: index.docker.io/springio/petclinic@sha256:fbb6f32dff6b4b05aa0bb4252a674a2084ecd26137793c88213385e62a6ea171
-  image: index.docker.io/springio/petclinic@sha256:fbb6f32dff6b4b05aa0bb4252a674a2084ecd26137793c88213385e62a6ea171
+          url: registry.replicated.com/spring-pet-clinic-stinkbug/petclinic@sha256:6a5c7ba0f125f61f73d89e308b20a7f792f0890578b7813366ffc1fa06dbbc82
+  image: registry.replicated.com/spring-pet-clinic-stinkbug/petclinic@sha256:6a5c7ba0f125f61f73d89e308b20a7f792f0890578b7813366ffc1fa06dbbc82
 kind: ImagesLock

--- a/bundle/config/spring-petclinic.yaml
+++ b/bundle/config/spring-petclinic.yaml
@@ -19,10 +19,12 @@ spec:
     spec:
       containers:
       - name: spring-petclinic
-        image: springio/petclinic:latest
+        image: registry.replicated.com/spring-pet-clinic-stinkbug/petclinic
         ports:
         - name: http
           containerPort: #@ data.values.app_port
+      imagePullSecrets:
+      - name: replicated-registry
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/spring-petclinic.yaml
+++ b/manifests/spring-petclinic.yaml
@@ -7,7 +7,9 @@ spec:
   serviceAccountName: kotsadm
   fetch:
   - imgpkgBundle:
-      image: registry.shortrib.dev/library/spring-petclinic-replicated:latest
+      image: registry.replicated.com/spring-pet-clinic-stinkbug/bundle@sha256:9fe8559d8b34e4750013eeb5b43c9ffaded2a53268d3b36b81ccd994f9acbce3
+      secretRef: 
+        name: replicated-registry
 
   template:
   - ytt:


### PR DESCRIPTION
TL;DR
-----

Shifts to the Replicated registry for the bundle and image

Details
-------

Uses the Replicated private registry to host the application
bundle and the Spring Pet Clinic image. This approach leverages
the private registry and customer license so that deployment is
self-contained.
