### PR TITLE
Creates and use a kapp package repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,12 @@ REGISTRY := registry.replicated.com
 PROJECT  := ${REPLICATED_APP}
 
 BUNDLE_DIR := ./bundle
+REPO_DIR := ./repository
 KOTS_DIR   := ./manifests
-
 
 BUNDLE_MANIFESTS := $(shell find $(BUNDLE_DIR) -name '*.yaml')
 KOTS_MANIFESTS := $(shell find $(KOTS_DIR) -name '*.yaml')
+REPO_MANIFESTS := $(shell find $(REPO_DIR) -name '*.yaml' -o -name '*.yml')
 
 lint: $(KOTS_MANIFESTS)
 	@replicated release lint --yaml-dir $(KOTS_DIR)
@@ -23,6 +24,9 @@ image: lock
 
 bundle: image
 	@imgpkg push --bundle $(REGISTRY)/$(PROJECT)/bundle --file $(BUNDLE_DIR)
+
+repository: $(REPO_MANIFESTS)
+	@imgpkg push --bundle $(REGISTRY)/$(PROJECT)/repository --file $(REPO_DIR)
 
 release: $(KOTS_MANIFESTS)
 	@replicated release create \

--- a/manifests/kots-registry-secret.yaml
+++ b/manifests/kots-registry-secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: replicated-registry
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: repl{{ LicenseDockerCfg }} 

--- a/manifests/package-repository.yaml
+++ b/manifests/package-repository.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageRepository
+metadata:
+  name: spring-petclinic-repository
+spec:
+  fetch:
+    imgpkgBundle:
+      image: registry.replicated.com/spring-pet-clinic-stinkbug/repository@sha256:b4eb1a669ef978dda9dc440a07c393f7db1b2af5803f9fbe25e159ff2d26e07c
+      secretRef:
+        name: replicated-registry

--- a/manifests/spring-petclinic.yaml
+++ b/manifests/spring-petclinic.yaml
@@ -1,32 +1,27 @@
 ---
-apiVersion: kappctrl.k14s.io/v1alpha1
-kind: App
+apiVersion: packaging.carvel.dev/v1alpha1
+kind: PackageInstall
 metadata:
   name: spring-petclinic
+  annotations:
+    ext.packaging.carvel.dev/fetch-0-secret-name: replicated-registry
 spec:
   serviceAccountName: kotsadm
-  fetch:
-  - imgpkgBundle:
-      image: registry.replicated.com/spring-pet-clinic-stinkbug/bundle@sha256:9fe8559d8b34e4750013eeb5b43c9ffaded2a53268d3b36b81ccd994f9acbce3
-      secretRef: 
-        name: replicated-registry
-
-  template:
-  - ytt:
-      paths:
-      - config/
-      inline:
-        paths:
-          values.yaml: |
-            #@data/values
-            ---
-            svc_port: repl{{ ConfigOption "service_port" | ParseInt }}
-            app_port: repl{{ ConfigOption "app_port" | ParseInt }}
-            namespace: repl{{ Namespace }}
-  - kbld:
-      paths:
-      - '-'
-      - .imgpkg/images.yml
-
-  deploy:
-    - kapp: {}
+  packageRef:
+    refName: spring-petclinic.spring.io
+    versionSelection:
+      constraints: 1.0.0
+  values:
+  - secretRef:
+      name: spring-petclinic-values
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: spring-petclinic-values
+stringData:
+  values.yaml: |
+    ---
+    svc_port: repl{{ ConfigOption "service_port" | ParseInt }}
+    app_port: repl{{ ConfigOption "app_port" | ParseInt }}
+    namespace: repl{{ Namespace }}

--- a/repository/.imgpkg/images.yml
+++ b/repository/.imgpkg/images.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+images:
+- annotations:
+    kbld.carvel.dev/id: registry.replicated.com/spring-pet-clinic-stinkbug/bundle
+  image: registry.replicated.com/spring-pet-clinic-stinkbug/bundle@sha256:9fe8559d8b34e4750013eeb5b43c9ffaded2a53268d3b36b81ccd994f9acbce3
+kind: ImagesLock

--- a/repository/packages/spring-petclinic.spring.io/1.0.0.yml
+++ b/repository/packages/spring-petclinic.spring.io/1.0.0.yml
@@ -1,0 +1,38 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: spring-petclinic.spring.io.1.0.0
+spec:
+  refName: spring-petclinic.spring.io
+  version: 1.0.0
+  releaseNotes: |
+    Initial release of the Spring Pet Clinic app package
+  valuesSchema:
+    openAPIv3:
+      type: object
+      additionalProperties: false
+      properties:
+        svc_port:
+          type: integer
+          default: 80
+        app_port:
+          type: integer
+          default: 8080
+        namespace:
+          type: string
+          default: dev
+  template:
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: registry.replicated.com/spring-pet-clinic-stinkbug/bundle
+      template:
+      - ytt:
+          paths:
+          - config/
+      - kbld:
+          paths:
+          - .imgpkg/images.yml
+          - '-'
+      deploy:
+      - kapp: {}

--- a/repository/packages/spring-petclinic.spring.io/metadata.yml
+++ b/repository/packages/spring-petclinic.spring.io/metadata.yml
@@ -1,0 +1,11 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageMetadata
+metadata:
+  # This will be the name of our package
+  name: spring-petclinic.spring.io
+spec:
+  displayName: "Spring Pet Clinic"
+  longDescription: "The canonical demonstration of Spring, deployed using Carvel and KOTS"
+  shortDescription: "SA sample Spring-based application"
+  categories:
+  - demo


### PR DESCRIPTION
TL;DR
-----

Deploys Spring Pet Clinic with/from a Carvel package repository

Details
-------

Prepares a kapp package repository and deploys it to the Replicated
private registry. The repository references a package that's stored
in an imgpkg bundle in the registry (the same one we used to deploy
before). Spring Pet Clinic is installed via the package.

There were a few adjustments to make to make sure that the package
loaded correctly. A package install doesn't directly reference an
image pull secret when it pulls from a repository. I had to annotate
the install with a reference to the `replicated-registry` secret,
which we still create from the license file.
